### PR TITLE
Add system prompt customization

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package/src/hydra-ai/hydra-ai-backend.ts
+++ b/package/src/hydra-ai/hydra-ai-backend.ts
@@ -7,8 +7,12 @@ import { InputContext } from "./model/input-context";
 export default class HydraBackend {
   private aiService: AIService;
 
-  constructor(openAIKey: string, openAIModel = "gpt-4o") {
-    this.aiService = new AIService(openAIKey, openAIModel);
+  constructor(
+    openAIKey: string,
+    openAIModel = "gpt-4o",
+    systemInstructions?: string
+  ) {
+    this.aiService = new AIService(openAIKey, openAIModel, systemInstructions);
   }
 
   public async generateComponent(
@@ -25,5 +29,3 @@ export default class HydraBackend {
     return componentChoice;
   }
 }
-
-export const hydraBackend = new HydraBackend(process.env.OPENAI_API_KEY!);

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -13,7 +13,12 @@ interface ComponentRegistry {
 }
 
 export default class HydraClient {
+  systemInstructions?: string;
   private componentList: ComponentRegistry = {};
+
+  constructor(systemInstructions?: string) {
+    this.systemInstructions = systemInstructions;
+  }
 
   public registerComponent(
     name: string,
@@ -42,7 +47,8 @@ export default class HydraClient {
     message: string,
     callback: (
       message: string,
-      availableComponents: ComponentMetadata[]
+      availableComponents: ComponentMetadata[],
+      systemInstructions?: string
     ) => Promise<ComponentChoice> = chooseComponent
   ): Promise<GenerateComponentResponse> {
     const availableComponents = this.getAvailableComponents(this.componentList);
@@ -61,7 +67,11 @@ export default class HydraClient {
       this.componentList
     );
 
-    const response = await callback(messageWithData, componentMetadataList);
+    const response = await callback(
+      messageWithData,
+      componentMetadataList,
+      this.systemInstructions
+    );
     if (!response) {
       throw new Error("Failed to fetch component choice from backend");
     }

--- a/package/src/hydra-ai/hydra-server-action.ts
+++ b/package/src/hydra-ai/hydra-server-action.ts
@@ -4,15 +4,25 @@ import HydraBackend from "./hydra-ai-backend";
 import { ComponentChoice } from "./model/component-choice";
 import { ComponentMetadata } from "./model/component-metadata";
 
-let hydra: HydraBackend | null;
+let hydraBackend: HydraBackend | null;
 
 export default async function chooseComponent(
   message: string,
-  availableComponents: ComponentMetadata[]
+  availableComponents: ComponentMetadata[],
+  systemInstructions?: string
 ): Promise<ComponentChoice> {
-  if (!hydra) {
-    hydra = new HydraBackend(process.env.OPENAI_API_KEY ?? "");
-  }
+  const hydra = getHydraBackend(systemInstructions);
   const response = await hydra.generateComponent(message, availableComponents);
   return response;
 }
+
+const getHydraBackend = (systemInstructions?: string): HydraBackend => {
+  if (!hydraBackend) {
+    hydraBackend = new HydraBackend(
+      process.env.OPENAI_API_KEY ?? "",
+      "gpt-4o",
+      systemInstructions
+    );
+  }
+  return hydraBackend;
+};


### PR DESCRIPTION
Updates system prompt generation to allow user-injected custom system prompts, which is the initial text sent to the LLM to describe the AI's role.

Updates HydraClient constructor to allow for optional `systemInstructions` parameter.

If no custom systemInstructions are passed, the default (the instruction starting with "You are a UI/UX designer..." we've been using so far) is used automatically.

Also updates the structure of the `ai-service` slightly to make it more clear that we are generating 1. a system prompt and 2. a user or content prompt.