### PR TITLE
Add default timestamp context to every message

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.16",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ai",
-      "version": "0.0.16",
+      "version": "0.0.20",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",
         "drizzle-orm": "^0.33.0",
+        "luxon": "^3.5.0",
         "openai": "^4.52.0",
         "pg": "^8.12.0",
         "postcss": "^8.4.39",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/luxon": "^3.4.2",
         "@types/node": "^20.11.14",
         "drizzle-kit": "^0.24.0",
         "jest": "^29.7.0",
@@ -2061,6 +2063,12 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.14.12",
@@ -4453,6 +4461,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.20",
+  "version": "0.0.22",
   "description": "",
   "main": "dist/index.js",
   "files": [
@@ -26,6 +26,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/luxon": "^3.4.2",
     "@types/node": "^20.11.14",
     "drizzle-kit": "^0.24.0",
     "jest": "^29.7.0",
@@ -39,6 +40,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.19",
     "drizzle-orm": "^0.33.0",
+    "luxon": "^3.5.0",
     "openai": "^4.52.0",
     "pg": "^8.12.0",
     "postcss": "^8.4.39",

--- a/package/src/hydra-ai/context-utils.ts
+++ b/package/src/hydra-ai/context-utils.ts
@@ -1,0 +1,12 @@
+import { DateTime } from "luxon";
+
+export const getDefaultContextAdditions = (): string[] => {
+  return [
+    `The current iso timestamp is: ${DateTime.now().toISO()}, which includes the user's timezone.`,
+  ];
+};
+
+export const updateMessageWithContextAdditions = (message: string): string => {
+  const contextAdditions = getDefaultContextAdditions();
+  return `${message}\n\n${contextAdditions.join("\n")}`;
+};

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -1,4 +1,5 @@
 import React, { ComponentType } from "react";
+import { updateMessageWithContextAdditions } from "./context-utils";
 import {
   chooseComponent,
   hydrateComponent,
@@ -74,11 +75,17 @@ export default class HydraClient {
       toolResponse: any
     ) => Promise<ComponentChoice> = hydrateComponent
   ): Promise<GenerateComponentResponse | string> {
+    const messageWithContextAdditions =
+      updateMessageWithContextAdditions(message);
+
     const availableComponents = await this.getAvailableComponents(
       this.componentList
     );
 
-    const response = await getComponentChoice(message, availableComponents);
+    const response = await getComponentChoice(
+      messageWithContextAdditions,
+      availableComponents
+    );
     if (!response) {
       throw new Error("Failed to fetch component choice from backend");
     }
@@ -100,7 +107,7 @@ export default class HydraClient {
       const chosenComponent: AvailableComponent =
         availableComponents[response.componentName];
       const hydratedComponentChoice = await hydrateComponentWithToolResponse(
-        message,
+        messageWithContextAdditions,
         chosenComponent,
         toolResponse
       );


### PR DESCRIPTION
AI should know about certain context with every single message. For example, the user's current time (and timezone) should always be known.

Adds a method that updates each user message and adds default context.

So far default context only includes user's current timestamp