### PR TITLE
Add component description to generation prompt

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ai",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
At the final generation prompt, adds the component description to the prompt so the ai can take into account any user-defined instructions for how to fill the props of the chosen component.

Also reduces temperature of openai calls to improve consistency.