### PR TITLE
Allow openai model choice

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.27",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ai",
-      "version": "0.0.27",
+      "version": "0.0.31",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -27,9 +27,17 @@ export default class HydraClient {
   private componentList: ComponentRegistry = {};
   private chatHistory: ChatMessage[] = [];
   private model?: string;
+  private backendInitialized: boolean = false;
 
   constructor(model?: string) {
     this.model = model;
+  }
+
+  private async ensureBackendInitialized(): Promise<void> {
+    if (!this.backendInitialized) {
+      await initBackend(this.model);
+      this.backendInitialized = true;
+    }
   }
 
   public async registerComponent(
@@ -45,7 +53,7 @@ export default class HydraClient {
       contextToolDefinitions: ComponentContextToolMetadata[]
     ) => Promise<boolean> = saveComponent
   ): Promise<void> {
-    await initBackend(this.model);
+    await this.ensureBackendInitialized();
     const success = await callback(
       name,
       description,
@@ -84,7 +92,7 @@ export default class HydraClient {
       toolResponse: any
     ) => Promise<ComponentChoice> = hydrateComponent
   ): Promise<GenerateComponentResponse | string> {
-    await initBackend(this.model);
+    await this.ensureBackendInitialized();
     const messageWithContextAdditions =
       updateMessageWithContextAdditions(message);
 

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -3,6 +3,7 @@ import { updateMessageWithContextAdditions } from "./context-utils";
 import {
   chooseComponent,
   hydrateComponent,
+  initBackend,
   saveComponent,
 } from "./hydra-server-action";
 import { ComponentChoice } from "./model";
@@ -25,6 +26,11 @@ interface ComponentRegistry {
 export default class HydraClient {
   private componentList: ComponentRegistry = {};
   private chatHistory: ChatMessage[] = [];
+  private model?: string;
+
+  constructor(model?: string) {
+    this.model = model;
+  }
 
   public async registerComponent(
     name: string,
@@ -39,6 +45,7 @@ export default class HydraClient {
       contextToolDefinitions: ComponentContextToolMetadata[]
     ) => Promise<boolean> = saveComponent
   ): Promise<void> {
+    await initBackend(this.model);
     const success = await callback(
       name,
       description,
@@ -77,6 +84,7 @@ export default class HydraClient {
       toolResponse: any
     ) => Promise<ComponentChoice> = hydrateComponent
   ): Promise<GenerateComponentResponse | string> {
+    await initBackend(this.model);
     const messageWithContextAdditions =
       updateMessageWithContextAdditions(message);
 

--- a/package/src/hydra-ai/hydra-server-action.ts
+++ b/package/src/hydra-ai/hydra-server-action.ts
@@ -10,18 +10,17 @@ import {
 } from "./model/component-metadata";
 import { ComponentPropsMetadata } from "./model/component-props-metadata";
 
-let hydraBackend: HydraBackend | null;
+let hydraBackend: HydraBackend;
 
-const getHydraBackend = (): HydraBackend => {
+export async function initBackend(model?: string): Promise<void> {
   if (!hydraBackend) {
     hydraBackend = new HydraBackend(
       process.env.OPENAI_API_KEY ?? "",
-      "gpt-4o",
+      model,
       process.env.POSTGRES_DB_URL
     );
   }
-  return hydraBackend;
-};
+}
 
 export async function saveComponent(
   name: string,
@@ -29,8 +28,7 @@ export async function saveComponent(
   propsDefinition: ComponentPropsMetadata,
   contextToolDefinitions: ComponentContextToolMetadata[]
 ): Promise<boolean> {
-  const hydra = getHydraBackend();
-  const success = await hydra.registerComponent(
+  const success = await hydraBackend.registerComponent(
     name,
     description,
     propsDefinition,
@@ -43,8 +41,7 @@ export async function chooseComponent(
   messageHistory: ChatMessage[],
   availableComponents: AvailableComponents
 ): Promise<ComponentDecision> {
-  const hydra = getHydraBackend();
-  const response = await hydra.generateComponent(
+  const response = await hydraBackend.generateComponent(
     messageHistory,
     availableComponents
   );
@@ -56,8 +53,7 @@ export async function hydrateComponent(
   component: AvailableComponent,
   toolResponse: any
 ): Promise<ComponentDecision> {
-  const hydra = getHydraBackend();
-  const response = await hydra.hydrateComponentWithData(
+  const response = await hydraBackend.hydrateComponentWithData(
     messageHistory,
     component,
     toolResponse


### PR DESCRIPTION
Adds a constructer param to HydraClient to allow the user to specify which openAI model should be used behind the scenes.

Defaults to 'gpt-4o'.

If the provided value is not a valid model name, the client app will throw an error on `generateComponent` request