### PR TITLE
Initial progress updates callback

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ai",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -27,17 +27,13 @@ export default class HydraClient {
   private componentList: ComponentRegistry = {};
   private chatHistory: ChatMessage[] = [];
   private model?: string;
-  private backendInitialized: boolean = false;
 
   constructor(model?: string) {
     this.model = model;
   }
 
   private async ensureBackendInitialized(): Promise<void> {
-    if (!this.backendInitialized) {
-      await initBackend(this.model);
-      this.backendInitialized = true;
-    }
+    await initBackend(this.model);
   }
 
   public async registerComponent(
@@ -94,6 +90,7 @@ export default class HydraClient {
     ) => Promise<ComponentChoice> = hydrateComponent
   ): Promise<GenerateComponentResponse> {
     onProgressUpdate("Choosing component");
+    await this.ensureBackendInitialized();
     const availableComponents = await this.getAvailableComponents(
       this.componentList
     );
@@ -146,7 +143,6 @@ export default class HydraClient {
       availableComponents: AvailableComponents
     ) => Promise<ComponentDecision>
   ): Promise<ComponentDecision> {
-    await this.ensureBackendInitialized();
     const messageWithContextAdditions =
       updateMessageWithContextAdditions(message);
 
@@ -167,11 +163,6 @@ export default class HydraClient {
       this.chatHistory.push({ sender: "hydra", message: response.message });
       return response;
     }
-
-    const componentEntry = this.getComponentFromRegistry(
-      response.componentName,
-      this.componentList
-    );
 
     return response;
   }

--- a/package/src/hydra-ai/model/generate-component-response.ts
+++ b/package/src/hydra-ai/model/generate-component-response.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 
 export interface GenerateComponentResponse {
-  component: ReactElement;
+  component?: ReactElement;
   message: string;
 }


### PR DESCRIPTION
Adds an optional callback param to generateComponent that is called at different stages of component generation with a string describing the stage. 

- Currently the stage names are hardcoded, but in future we could allow configuration of what string is sent at each stage.
- We can update tool definitions to include a string that should be sent to the callback when that tool is being used, instead of "Getting additional data"
-  We can stream text back as it is received from OpenAI streaming request