### PR TITLE
Allow enum fields in tool parameters

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.32",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ai",
-      "version": "0.0.32",
+      "version": "0.0.35",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package/src/hydra-ai/ai-service.ts
+++ b/package/src/hydra-ai/ai-service.ts
@@ -280,15 +280,27 @@ ${this.generateZodTypePrompt(schema)}`;
           type: "object",
           properties: {
             ...Object.fromEntries(
-              tool.parameters.map((parameter) => [
-                parameter.name,
-                parameter.type === "array"
-                  ? {
+              tool.parameters.map((parameter) => {
+                if (parameter.type === "enum") {
+                  return [
+                    parameter.name,
+                    {
+                      type: "string",
+                      enum: parameter.enumValues || [],
+                    },
+                  ];
+                } else if (parameter.type === "array") {
+                  return [
+                    parameter.name,
+                    {
                       type: "array",
                       items: { type: parameter.items?.type || "string" },
-                    } // Handle array type
-                  : { type: parameter.type }, // Handle non-array types
-              ])
+                    },
+                  ];
+                } else {
+                  return [parameter.name, { type: parameter.type }];
+                }
+              })
             ),
           },
           required: tool.parameters

--- a/package/src/hydra-ai/model/component-metadata.ts
+++ b/package/src/hydra-ai/model/component-metadata.ts
@@ -12,10 +12,11 @@ export interface ComponentContextToolMetadata {
   description: string;
   parameters: {
     name: string;
-    type: string;
+    type: "string" | "number" | "array" | "enum";
     description: string;
     isRequired: boolean;
     items?: { type: string };
+    enumValues?: string[];
   }[];
 }
 

--- a/package/src/hydra-ai/model/component-metadata.ts
+++ b/package/src/hydra-ai/model/component-metadata.ts
@@ -12,7 +12,7 @@ export interface ComponentContextToolMetadata {
   description: string;
   parameters: {
     name: string;
-    type: "string" | "number" | "array" | "enum";
+    type: string;
     description: string;
     isRequired: boolean;
     items?: { type: string };


### PR DESCRIPTION
Allows tools to define parameters with enums, to make sure hydra calls functions with valid values for parameters that have a specific set of choices.