### PR TITLE
Allow HydraClient to request HydraApi if key and url provided

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.39",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ai",
-      "version": "0.0.39",
+      "version": "0.0.41",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.4.19",
@@ -8288,9 +8288,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-ai",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -38,7 +38,9 @@ export default class HydraClient {
   }
 
   private async ensureBackendInitialized(): Promise<void> {
-    await initBackend(this.model, this.provider as Provider | undefined);
+    if (!this.hydraApiKey) {
+      await initBackend(this.model, this.provider as Provider | undefined);
+    }
   }
 
   public async registerComponent(

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -30,25 +30,32 @@ export default class HydraClient {
   private model?: string;
   private provider?: string;
   private hydraApiKey?: string;
+  private hydraApiUrl?: string;
 
-  constructor(model?: string, provider?: string, hydraApiKey?: string) {
+  constructor(
+    model?: string,
+    provider?: string,
+    hydraApiKey?: string,
+    hydraApiUrl?: string
+  ) {
     this.model = model;
     this.provider = provider;
     this.hydraApiKey = hydraApiKey;
+    this.hydraApiUrl = hydraApiUrl;
   }
 
-  private async ensureBackendInitialized(): Promise<void> {
+  private ensureBackendInitialized = async (): Promise<void> => {
     if (!this.hydraApiKey) {
       await initBackend(this.model, this.provider as Provider | undefined);
     }
-  }
+  };
 
-  private async storeComponent(
+  private storeComponent = async (
     name: string,
     description: string,
     propsDefinition: ComponentPropsMetadata,
     contextToolDefinitions: ComponentContextToolMetadata[]
-  ): Promise<boolean> {
+  ): Promise<boolean> => {
     if (!this.hydraApiKey) {
       await this.ensureBackendInitialized();
       return saveComponent(
@@ -59,7 +66,7 @@ export default class HydraClient {
       );
     }
     return true;
-  }
+  };
 
   public async registerComponent(
     name: string,
@@ -122,13 +129,15 @@ export default class HydraClient {
     getComponentChoice: (
       messageHistory: ChatMessage[],
       availableComponents: AvailableComponents,
-      apiKey?: string
+      apiKey?: string,
+      url?: string
     ) => Promise<ComponentDecision> = this.getDefaultComponentChoiceFunction(),
     hydrateComponentWithToolResponse: (
       messageHistory: ChatMessage[],
       component: AvailableComponent,
       toolResponse: any,
-      apiKey?: string
+      apiKey?: string,
+      url?: string
     ) => Promise<ComponentChoice> = this.getDefaultHydrateComponentFunction()
   ): Promise<GenerateComponentResponse> {
     onProgressUpdate("Choosing component");
@@ -183,7 +192,8 @@ export default class HydraClient {
     getComponentChoice: (
       messageHistory: ChatMessage[],
       availableComponents: AvailableComponents,
-      apiKey?: string
+      apiKey?: string,
+      url?: string
     ) => Promise<ComponentDecision>
   ): Promise<ComponentDecision> {
     const messageWithContextAdditions =
@@ -197,7 +207,8 @@ export default class HydraClient {
     const response = await getComponentChoice(
       this.chatHistory,
       availableComponents,
-      this.hydraApiKey
+      this.hydraApiKey,
+      this.hydraApiUrl
     );
     if (!response) {
       throw new Error("Failed to fetch component choice from backend");
@@ -218,7 +229,8 @@ export default class HydraClient {
       messageHistory: ChatMessage[],
       component: AvailableComponent,
       toolResponse: any,
-      apiKey?: string
+      apiKey?: string,
+      url?: string
     ) => Promise<ComponentDecision>
   ): Promise<GenerateComponentResponse> {
     if (!response.componentName) {
@@ -231,7 +243,8 @@ export default class HydraClient {
       this.chatHistory,
       chosenComponent,
       toolResponse,
-      this.hydraApiKey
+      this.hydraApiKey,
+      this.hydraApiUrl
     );
 
     if (!hydratedComponentChoice.componentName) {

--- a/package/src/hydra-ai/hydra-ai-client.ts
+++ b/package/src/hydra-ai/hydra-ai-client.ts
@@ -43,21 +43,38 @@ export default class HydraClient {
     }
   }
 
+  private async storeComponent(
+    name: string,
+    description: string,
+    propsDefinition: ComponentPropsMetadata,
+    contextToolDefinitions: ComponentContextToolMetadata[]
+  ): Promise<boolean> {
+    if (!this.hydraApiKey) {
+      await this.ensureBackendInitialized();
+      return saveComponent(
+        name,
+        description,
+        propsDefinition,
+        contextToolDefinitions
+      );
+    }
+    return true;
+  }
+
   public async registerComponent(
     name: string,
     description: string,
     component: ComponentType<any>,
     propsDefinition: ComponentPropsMetadata = {},
     contextTools: ComponentContextTool[] = [],
-    callback: (
+    storeComponent: (
       name: string,
       description: string,
       propsDefinition: ComponentPropsMetadata,
       contextToolDefinitions: ComponentContextToolMetadata[]
-    ) => Promise<boolean> = saveComponent
+    ) => Promise<boolean> = this.storeComponent
   ): Promise<void> {
-    await this.ensureBackendInitialized();
-    const success = await callback(
+    const success = await storeComponent(
       name,
       description,
       propsDefinition,

--- a/package/src/hydra-ai/hydra-api/hydra-api-service.ts
+++ b/package/src/hydra-ai/hydra-api/hydra-api-service.ts
@@ -6,19 +6,21 @@ import {
   AvailableComponents,
 } from "../model/component-metadata";
 
-const BASE_URL = "http://localhost:3000";
-
 export const hydraGenerate = async (
   messageHistory: ChatMessage[],
   availableComponents: AvailableComponents,
-  apiKey?: string
+  apiKey?: string,
+  url?: string
 ): Promise<ComponentDecision> => {
   if (!apiKey) {
     throw new Error("API key is required for using hydraAPI");
   }
+  if (!url) {
+    throw new Error("URL is required for using hydraAPI");
+  }
 
   try {
-    const response = await fetch(`${BASE_URL}/components/generate`, {
+    const response = await fetch(`${url}/components/generate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -46,13 +48,17 @@ export const hydraHydrate = async (
   messageHistory: ChatMessage[],
   component: AvailableComponent,
   toolResponse: any,
-  apiKey?: string
+  apiKey?: string,
+  url?: string
 ): Promise<ComponentChoice> => {
   if (!apiKey) {
     throw new Error("API key is required for using hydraAPI");
   }
+  if (!url) {
+    throw new Error("URL is required for using hydraAPI");
+  }
   try {
-    const response = await fetch(`${BASE_URL}/components/hydrate`, {
+    const response = await fetch(`${url}/components/hydrate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/package/src/hydra-ai/hydra-api/hydra-api-service.ts
+++ b/package/src/hydra-ai/hydra-api/hydra-api-service.ts
@@ -1,0 +1,78 @@
+import { ComponentChoice } from "../model";
+import { ChatMessage } from "../model/chat-message";
+import { ComponentDecision } from "../model/component-choice";
+import {
+  AvailableComponent,
+  AvailableComponents,
+} from "../model/component-metadata";
+
+const BASE_URL = "http://localhost:3000/components";
+
+export const hydraGenerate = async (
+  messageHistory: ChatMessage[],
+  availableComponents: AvailableComponents,
+  apiKey?: string
+): Promise<ComponentDecision> => {
+  if (!apiKey) {
+    throw new Error("API key is required for using hydraAPI");
+  }
+
+  try {
+    const response = await fetch(`${BASE_URL}/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body: JSON.stringify({
+        messageHistory,
+        availableComponents,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to generate component");
+    }
+
+    const result = await response.json();
+    return result as ComponentDecision;
+  } catch (error) {
+    console.error("Error in hydraGenerate:", error);
+    throw error;
+  }
+};
+
+export const hydraHydrate = async (
+  messageHistory: ChatMessage[],
+  component: AvailableComponent,
+  toolResponse: any,
+  apiKey?: string
+): Promise<ComponentChoice> => {
+  if (!apiKey) {
+    throw new Error("API key is required for using hydraAPI");
+  }
+  try {
+    const response = await fetch(`${BASE_URL}/hydrate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body: JSON.stringify({
+        messageHistory,
+        component,
+        toolResponse,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to hydrate component");
+    }
+
+    const result = await response.json();
+    return result as ComponentChoice;
+  } catch (error) {
+    console.error("Error in hydraHydrate:", error);
+    throw error;
+  }
+};

--- a/package/src/hydra-ai/hydra-api/hydra-api-service.ts
+++ b/package/src/hydra-ai/hydra-api/hydra-api-service.ts
@@ -6,7 +6,7 @@ import {
   AvailableComponents,
 } from "../model/component-metadata";
 
-const BASE_URL = "http://localhost:3000/components";
+const BASE_URL = "http://localhost:3000";
 
 export const hydraGenerate = async (
   messageHistory: ChatMessage[],
@@ -18,7 +18,7 @@ export const hydraGenerate = async (
   }
 
   try {
-    const response = await fetch(`${BASE_URL}/generate`, {
+    const response = await fetch(`${BASE_URL}/components/generate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -52,7 +52,7 @@ export const hydraHydrate = async (
     throw new Error("API key is required for using hydraAPI");
   }
   try {
-    const response = await fetch(`${BASE_URL}/hydrate`, {
+    const response = await fetch(`${BASE_URL}/components/hydrate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./hydra-ai/helper-components/hydra-chat";
-export { default as HydraBackend } from "./hydra-ai/hydra-ai-backend";
 export { default as HydraClient } from "./hydra-ai/hydra-ai-client";
 export { chooseComponent, saveComponent } from "./hydra-ai/hydra-server-action";
 export * from "./hydra-ai/model";


### PR DESCRIPTION
Updates HydraClient to request generation and hydration from a "Hydra API" instead of from the NextJS server actions, for those who don't want to maintain their own "backend"